### PR TITLE
Add component type as tags in diagram

### DIFF
--- a/startleft/diagram.py
+++ b/startleft/diagram.py
@@ -141,10 +141,6 @@ class Diagram:
 
     def load_map(self, map):
         always_merger.merge(self.map, map)
-        # add type as tags in diagram
-        for mapElement in map['components']:
-            if mapElement['type'] != 'default':
-                mapElement['properties']['ir.tags'] = mapElement['type']
 
     def add_trustzone(self, trustzone):
         tz = Trustzone(trustzone)
@@ -159,6 +155,7 @@ class Diagram:
     def add_component(self, component):
         c = Component(component)
         c.merge_properties(self.map["components"])
+        c.data['properties']['ir.tags'] = c.data['type']
 
         c_cell = c.to_cell()        
         cell = etree.SubElement(self.root, "mxCell", id=c_cell["data"]["id"], value=c_cell["data"]["name"], style=c_cell["style"], parent=c_cell["data"]["parent"], vertex="1")

--- a/startleft/diagram.py
+++ b/startleft/diagram.py
@@ -79,7 +79,8 @@ class Component(Cell):
         self.ir_map = {
             "ir.type": "COMPONENT",
             "ir.synchronized": "1",
-            "ir.componentDefinition.ref": "empty-component"
+            "ir.componentDefinition.ref": "empty-component",
+            "ir.tags": ""
         }
         self.style_map = {
             "outlineConnect": "0",
@@ -140,6 +141,10 @@ class Diagram:
 
     def load_map(self, map):
         always_merger.merge(self.map, map)
+        # add type as tags in diagram
+        for mapElement in map['components']:
+            if mapElement['type'] != 'default':
+                mapElement['properties']['ir.tags'] = mapElement['type']
 
     def add_trustzone(self, trustzone):
         tz = Trustzone(trustzone)

--- a/startleft/iriusrisk.py
+++ b/startleft/iriusrisk.py
@@ -182,7 +182,9 @@ class IriusRisk:
         xml_components = etree.SubElement(xml_project, "components")
         for component in self.components:
             xml_component = etree.SubElement(xml_components, "component", ref=component["id"], name=component["name"], desc="", library="", parentComponentRef="", componentDefinitionRef=component["component_definition"], asvsVersion="4")
-            etree.SubElement(xml_component, "tags")
+            xml_component_tags = etree.SubElement(xml_component, "tags")
+            # add type as tags in xml
+            etree.SubElement(xml_component_tags, "tag", tag=component['type'])
             etree.SubElement(xml_component, "questions")
             xml_component_trustzones = etree.SubElement(xml_component, "trustZones")
             etree.SubElement(xml_component_trustzones, "trustZone", ref=component["trustzone"])


### PR DESCRIPTION
The tags must be setted in two different places:

- In the mxCell inside the diagram definition
- On each component of the xml