### PR TITLE
[feature/OTM-7] parent component search actions with default values

### DIFF
--- a/startleft/data/mapping_schema.json
+++ b/startleft/data/mapping_schema.json
@@ -191,6 +191,25 @@
                             }
                         }
                     ]
+                },
+                {
+                    "type": "object",
+                    "required": ["$searchParams"],
+                    "properties": {
+                        "searchPath": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },{
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "defaultValue": {
+                            "type": "string"
+                        }
+                    }
+
                 }
             ]
         }

--- a/startleft/sourcemodel.py
+++ b/startleft/sourcemodel.py
@@ -80,16 +80,15 @@ class SourceModel:
                 return jmespath.search(obj["$root"], self.data, options=self.jmespath_options)
 
             if "$path" in obj:
-                try:
-                    return jmespath.search(obj["$path"], source, options=self.jmespath_options)
-                except:
-                    return []
+                if "$searchParams" in obj["$path"]:
+                    return self.__search_with_default(obj, source, "$path")
+                else:
+                    return self.__jmespath_search(obj["$path"], source)
 
             if "$format" in obj:
                 return obj["$format"].format(**source)
 
             if "$catchall" in obj:
-                #eturn jmespath.search(obj["$catchall"], self.data, options=self.jmespath_options)
                 return self.search(obj["$catchall"], source)
 
             if "$children" in obj:
@@ -110,12 +109,47 @@ class SourceModel:
                 return results
 
             if "$findFirst" in obj:
-                for search_path in obj["$findFirst"]:
-                    try:
-                        search_result = jmespath.search(search_path, source, options=self.jmespath_options)
-                        if search_result is not None:
-                            return search_result
-                    except:
-                        return []
-
+                if "$searchParams" in obj["$findFirst"]:
+                    return self.__search_with_default(obj, source, "$findFirst")
+                else:
+                    return self.__find_first_search(obj["$findFirst"], source)
             return obj
+
+    def __search_with_default(self, obj, source, action):
+        try:
+            search_params = obj[action]["$searchParams"]
+
+            if "searchPath" in search_params:
+                if action == "$path":
+                    search_result = self.__jmespath_search(search_params["searchPath"], source)
+                elif action == "$findFirst":
+                    search_result = self.__find_first_search(search_params["searchPath"], source)
+                else:
+                    return []
+
+                if search_result is None:
+                    if "defaultValue" in search_params:
+                        try:
+                            return search_params["defaultValue"]
+                        except:
+                            return []
+                    else:
+                        return []
+                else:
+                    return search_result
+            else:
+                return []
+        except:
+            return []
+
+    def __jmespath_search(self, search_path, source):
+        try:
+            return jmespath.search(search_path, source, options=self.jmespath_options)
+        except:
+            return []
+
+    def __find_first_search(self, search_path_root, source):
+        for search_path in search_path_root:
+            search_result = self.__jmespath_search(search_path, source)
+            if search_result is not None:
+                return search_result


### PR DESCRIPTION
both actions $path and $findFirst are provided an additional capability. A comparison between both ways to operate:
Simple way, no default value:
$path: "path"
$findFirst:[ "path 1", "path 2"]

New aditional way, with default value:
$path: {$searchParams:{ searchPath: "path", defaultValue: "public"}}
$findFirst: {$searchParams:{ searchPath: ["path 1", "path 2"], defaultValue: "default parent id"}}

So this new way is using a structure like this:
**$searchParams**:{
 **searchPath**: ["path 1", "path 2"],
 **defaultValue**: "default parent id"
}
searchPath, as in findFirst's array, may contain more than a path.
Important: this methods only look inside the target component to generate but do not check the real existence of parent target component, that is assumed.

**Examples:**
parent:      {$path: {$searchParams:{ searchPath: "Properties.VpcId.Ref", defaultValue: "public"}}}
parent:      {$findFirst: {$searchParams:{ searchPath: ["Properties.SubnetIds[].Ref", "Properties.VpcId.Ref"], defaultValue: "public"}}}
