### PR TITLE
Corrected invalid minlength/maxlength properties

### DIFF
--- a/otm/resources/schemas/otm_schema.json
+++ b/otm/resources/schemas/otm_schema.json
@@ -215,9 +215,7 @@
     "definitions": {
         "uuid": {
             "type": "string",
-            "minlength": 1,
-            "maxlength": 36,
-            "pattern": "^(?![nN][uU][lL]{2}$)\\s*\\S.*"
+            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "size": {
             "type": "object",


### PR DESCRIPTION
The properties "minlength" and "maxlength" are invalid. JSON Schema draft-7 states the properties are "minLength" and "maxLength". Additionally, the regex did not validate UUIDs. A new pattern was introduced that does validate UUIDs that are 36 characters in length.