### PR TITLE
Fixed invalid otmVersion property. Added metadata

### DIFF
--- a/otm/resources/schemas/otm_schema.json
+++ b/otm/resources/schemas/otm_schema.json
@@ -1,6 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "otmVersion": "0.1.0",
+    "$id": "https://iriusrisk.com/schema/otm-0.1.0.schema.json",
+    "title": "Open Threat Model Specification",
+    "$comment" : "Open Threat Model JSON schema is published under the terms of the Apache License 2.0.",
     "type": "object",
     "required": ["project", "otmVersion"],
     "properties": {


### PR DESCRIPTION
The property "otmVersion" is not valid and causes warnings with some JSON schema validators. Added $id with that specifies the unique identification of the schema which includes the version. Added title and license statement to schema.