### PR TITLE
[bugfix/OPT-982] to [release/1.18.0]

### DIFF
--- a/slp_mtmt/slp_mtmt/parse/mtmt_threat_parser.py
+++ b/slp_mtmt/slp_mtmt/parse/mtmt_threat_parser.py
@@ -9,12 +9,21 @@ from slp_mtmt.slp_mtmt.mtmt_entity import MTMT
 
 
 def get_threat_description(threat: MTMThreat):
-    return remove_trailing_dot(re.split("\\.\\s*Consider", threat.long_description)[0])
+    if threat.long_description:
+        return remove_trailing_dot(re.split("\\.\\s*Consider", threat.long_description)[0])
+    if threat.short_description:
+        return remove_trailing_dot(re.split("\\.\\s*Consider", threat.short_description)[0])
+    return None
 
 
 def get_mitigation_description(threat: MTMThreat):
-    description = re.match(".*(Consider.+\\.)", threat.long_description)
-    return remove_trailing_dot(description.group(1)) if description else None
+    if threat.long_description:
+        description = re.match(".*(Consider.+\\.)", threat.long_description)
+        return remove_trailing_dot(description.group(1)) if description else None
+    if threat.short_description:
+        description = re.match(".*(Consider.+\\.)", threat.short_description)
+        return remove_trailing_dot(description.group(1)) if description else None
+    return None
 
 
 def get_first_sentence(message: str):

--- a/slp_mtmt/tests/unit/parse/test_mtmt_threat_parser.py
+++ b/slp_mtmt/tests/unit/parse/test_mtmt_threat_parser.py
@@ -318,3 +318,51 @@ class TestMTMThreatParser:
         message_without_trailing_dot = remove_trailing_dot(message)
 
         assert message_without_trailing_dot == expected_message
+
+    def test_long_description(self):
+        threat = MTMThreat({
+            "Value": {
+                "Properties": {
+                    "KeyValueOfstringstring": [
+                        {
+                            "Key": "UserThreatDescription",
+                            "Value": "This is a long description. Consider this."
+                        }
+                    ]
+                }
+            }
+        })
+        result = get_threat_description(threat)
+        assert result == "This is a long description"
+
+    def test_short_description(self):
+        threat = MTMThreat({
+            "Value": {
+                "Properties": {
+                    "KeyValueOfstringstring": [
+                        {
+                            "Key": "UserThreatShortDescription",
+                            "Value": "No Short description. Consider that."
+                        }
+                    ]
+                }
+            }
+        })
+        result = get_threat_description(threat)
+        assert result == "No Short description"
+
+    def test_no_description(self):
+        threat = MTMThreat({
+            "Value": {
+                "Properties": {
+                    "KeyValueOfstringstring": [
+                        {
+                            "Key": "NonRealKey",
+                            "Value": "This is a value for a non real key."
+                        }
+                    ]
+                }
+            }
+        })
+        result = get_threat_description(threat)
+        assert result is None


### PR DESCRIPTION
Parser now try to get long description by default, if not try to get short description if none of them are present description field will be empty.